### PR TITLE
Updated order_management Dockerfile

### DIFF
--- a/order_management/Dockerfile
+++ b/order_management/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM rust:1.64 AS buildbase
+FROM --platform=$BUILDPLATFORM rust:1.67 AS buildbase
 WORKDIR /src
 RUN <<EOT bash
     set -ex


### PR DESCRIPTION
Upgraded Rust version to 1.67 in order to satisfy requirements of the order_management dependencies.

Using Rust 1.64 will generate the following errors:

```
error: package `time-core v0.1.1` cannot be built because it requires rustc 1.65.0 or newer, while the currently active rustc version is 1.64.0
Error: error building at STEP "RUN cargo build --target wasm32-wasi --release": error while running runtime: exit status 101

```

Using Rust 1.65 will generate the following errors:

```
error: package `time v0.3.28` cannot be built because it requires rustc 1.67.0 or newer, while the currently active rustc version is 1.65.0
Either upgrade to rustc 1.67.0 or newer, or use
cargo update -p time@0.3.28 --precise ver
where `ver` is the latest version of `time` supporting rustc 1.65.0
Error: error building at STEP "RUN cargo build --target wasm32-wasi --release": error while running runtime: exit status 101
```