### PR TITLE
Added Podman Containerfiles

### DIFF
--- a/order_management/Containerfile
+++ b/order_management/Containerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM rust:1.67 AS buildbase
+WORKDIR /src
+RUN apt-get update && apt-get install -y git clang
+RUN rustup target add wasm32-wasi
+
+# This line installs WasmEdge including the AOT compiler
+RUN curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash
+
+FROM buildbase AS build
+COPY Cargo.toml .
+COPY src ./src 
+# Build the Wasm binary
+RUN cargo build --target wasm32-wasi --release
+# This line builds the AOT Wasm binary
+RUN /root/.wasmedge/bin/wasmedgec target/wasm32-wasi/release/order_management.wasm order_management.wasm
+
+FROM scratch
+ENTRYPOINT [ "order_management.wasm" ]
+COPY --from=build /src/order_management.wasm /order_management.wasm

--- a/sales_tax_rate/Containerfile
+++ b/sales_tax_rate/Containerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM rust:1.64 AS buildbase
+WORKDIR /src
+RUN apt-get update && apt-get install -y git clang
+RUN rustup target add wasm32-wasi
+
+# This line installs WasmEdge including the AOT compiler
+RUN curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash
+
+FROM buildbase AS build
+COPY Cargo.toml .
+COPY src ./src 
+# Build the Wasm binary
+RUN cargo build --target wasm32-wasi --release
+# This line builds the AOT Wasm binary
+RUN /root/.wasmedge/bin/wasmedgec target/wasm32-wasi/release/sales_tax_rate_lookup.wasm sales_tax_rate_lookup.wasm
+
+FROM scratch
+ENTRYPOINT [ "/sales_tax_rate_lookup.wasm" ]
+COPY --from=build /src/sales_tax_rate_lookup.wasm /sales_tax_rate_lookup.wasm


### PR DESCRIPTION
Added Containerfiles for the order_management and sales_tax_rate in order to properly support Podman.

The supported syntax differs a bit between Docker and Podman, but using a separate set of files for Podman solves this issue.

Tested with:
podman version 1.6.4
